### PR TITLE
Update foxglove subprotocol to foxglove.sdk.v1

### DIFF
--- a/desktop/foxglove/bridge.py
+++ b/desktop/foxglove/bridge.py
@@ -84,7 +84,7 @@ class FoxgloveBridge:
             # Connect to WebSocket server with Foxglove protocol
             self.websocket = await websockets.connect(
                 f"ws://{self.pi_ip}:{self.port}",
-                subprotocols=["foxglove.websocket.v1"],
+                subprotocols=["foxglove.sdk.v1"],
             )
             
             if self.websocket is None:

--- a/desktop/foxglove/protocol.py
+++ b/desktop/foxglove/protocol.py
@@ -84,18 +84,16 @@ async def advertise_twist_channel(
         Exception: If WebSocket send fails
     """
     advertise_message = {
-        "op": "advertise",
-        "channels": [
-            {
-                "id": channel_id,
-                "topic": topic,
-                "encoding": ENCODING_JSON,
-                "schemaName": "geometry_msgs/msg/TwistStamped",
-                "schemaEncoding": SCHEMA_ENCODING_ROS2MSG,
-                "schema": TWIST_STAMPED_SCHEMA,
-            }
-        ],
-    }
+            "op": "advertise",
+            "channels": [
+                {
+                    "id": channel_id,
+                    "topic": topic,
+                    "encoding": "json",
+                    "schemaName": "geometry_msgs/msg/TwistStamped",
+                }
+            ],
+        }
     await websocket.send(json.dumps(advertise_message))
 
 
@@ -129,17 +127,11 @@ def build_twist_stamped_frame(
     """
     # Build TwistStamped message
     twist_stamped_data = {
-        "header": {
-            "stamp": {
-                "sec": 0,
-                "nanosec": 0
-            },
-            "frame_id": frame_id
-        },
+        "header": {"stamp": {"sec": 0, "nanosec": 0}, "frame_id": frame_id},
         "twist": {
             "linear": {"x": linear_x, "y": linear_y, "z": linear_z},
-            "angular": {"x": angular_x, "y": angular_y, "z": angular_z}
-        }
+            "angular": {"x": angular_x, "y": angular_y, "z": angular_z},
+        },
     }
     
     # Encode payload as JSON


### PR DESCRIPTION
# Issue

#50 

# Description

Foxglove websocket subprotocol changed to "foxglove.sdk.v1"

Additionally, from our in-class test, it seems like there wasn't a need for schemaEncoding nor schema
in the advertisement payload; so it was removed. If this actually is needed, it can be added back.