### PR TITLE
adding lidar transforms

### DIFF
--- a/ros2_ws/src/slu_smart/launch/lidar_launch.launch.py
+++ b/ros2_ws/src/slu_smart/launch/lidar_launch.launch.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    # --- LiDAR driver args ---
+    serial_port = LaunchConfiguration("serial_port")
+    serial_baudrate = LaunchConfiguration("serial_baudrate")
+    lidar_frame = LaunchConfiguration("lidar_frame")
+    inverted = LaunchConfiguration("inverted")
+    angle_compensate = LaunchConfiguration("angle_compensate")
+    scan_mode = LaunchConfiguration("scan_mode")
+
+    # --- Static TF args (base_link -> lidar_frame) ---
+    tf_x = LaunchConfiguration("tf_x")
+    tf_y = LaunchConfiguration("tf_y")
+    tf_z = LaunchConfiguration("tf_z")
+    tf_roll = LaunchConfiguration("tf_roll")
+    tf_pitch = LaunchConfiguration("tf_pitch")
+    tf_yaw = LaunchConfiguration("tf_yaw")
+    parent_frame = LaunchConfiguration("parent_frame")
+
+    return LaunchDescription([
+        # LiDAR settings
+        DeclareLaunchArgument("serial_port", default_value="/dev/ttyUSB0"),
+        DeclareLaunchArgument("serial_baudrate", default_value="115200"),  # A1 default
+        DeclareLaunchArgument("lidar_frame", default_value="laser"),       # child frame
+        DeclareLaunchArgument("inverted", default_value="false"),
+        DeclareLaunchArgument("angle_compensate", default_value="true"),
+        DeclareLaunchArgument("scan_mode", default_value="Sensitivity"),
+
+        # TF settings (edit these for your robot)
+        DeclareLaunchArgument("parent_frame", default_value="base_link"),
+        DeclareLaunchArgument("tf_x", default_value="0.00"),   # meters
+        DeclareLaunchArgument("tf_y", default_value="0.00"),
+        DeclareLaunchArgument("tf_z", default_value="0.15"),
+        DeclareLaunchArgument("tf_roll", default_value="0.0"),   # radians
+        DeclareLaunchArgument("tf_pitch", default_value="0.0"),
+        DeclareLaunchArgument("tf_yaw", default_value="0.0"),
+
+        # sllidar driver node
+        Node(
+            package="sllidar_ros2",
+            executable="sllidar_node",
+            name="sllidar_node",
+            output="screen",
+            parameters=[{
+                "channel_type": "serial",
+                "serial_port": serial_port,
+                "serial_baudrate": serial_baudrate,
+                "frame_id": lidar_frame,
+                "inverted": inverted,
+                "angle_compensate": angle_compensate,
+                "scan_mode": scan_mode,
+            }],
+        ),
+
+        # Static transform: base_link -> laser
+        Node(
+            package="tf2_ros",
+            executable="static_transform_publisher",
+            name="lidar_static_tf",
+            arguments=[
+                "--x", tf_x,
+                "--y", tf_y,
+                "--z", tf_z,
+                "--roll", tf_roll,
+                "--pitch", tf_pitch,
+                "--yaw", tf_yaw,
+                "--frame-id", parent_frame,
+                "--child-frame-id", lidar_frame,
+            ],
+            output="screen",
+        ),
+    ])

--- a/ros2_ws/src/slu_smart/setup.py
+++ b/ros2_ws/src/slu_smart/setup.py
@@ -1,4 +1,6 @@
 from setuptools import find_packages, setup
+from glob import glob
+import os
 
 package_name = 'slu_smart'
 
@@ -10,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
@@ -20,7 +23,8 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-                'talker = slu_smart.test_pub:main',
+            'talker = slu_smart.test_pub:main',
+            'test_vel = slu_smart.cmd_vel_stamped_pub:main',
         ],
     },
 )

--- a/ros2_ws/src/slu_smart/slu_smart/cmd_vel_stamped_pub.py
+++ b/ros2_ws/src/slu_smart/slu_smart/cmd_vel_stamped_pub.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import TwistStamped
+
+class CmdVelStampedPub(Node):
+    def __init__(self):
+        super().__init__('cmd_vel_stamped_pub')
+        self.pub = self.create_publisher(TwistStamped, '/diff_drive_base/cmd_vel', 10)
+        self.timer = self.create_timer(0.1, self.tick)  # 10 Hz
+        self.lin_x = 2.0
+        self.ang_z = 0.0
+
+    def tick(self):
+        msg = TwistStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = 'base_link'
+        msg.twist.linear.x = self.lin_x
+        msg.twist.angular.z = self.ang_z
+        self.pub.publish(msg)
+
+def main():
+    rclpy.init()
+    node = CmdVelStampedPub()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
We want to ensure that the lidar frame (and its scan) will remain relative to the robot's base_link (its base plate) over time. I made a custom transform in a launch with the lidar camera that will remain constant over time, even if the robot moves.

## Acceptance Criteria:
- [x] Lidar still works as expected on launch (the /scan topic exists).
- [x] The transform between the lidar and the robot is accurate.
- [x] The launch is localized to our personalized slu MORPH package.